### PR TITLE
Direct pull of paste support v2

### DIFF
--- a/bridge/irc/irc.go
+++ b/bridge/irc/irc.go
@@ -274,7 +274,7 @@ func (b *Birc) Send(msg config.Message) (string, error) {
 	}
 
 	if b.PasteDomain != "" && b.PasteCodeblocks {
-		m1 := regexp.MustCompile("(?ms)```(.*)```")
+		m1 := regexp.MustCompile("(?ms)```(.*?)```")
 
 		for true {
 			loc := m1.FindStringIndex(msg.Text)

--- a/bridge/irc/irc.go
+++ b/bridge/irc/irc.go
@@ -139,7 +139,8 @@ func (b *Birc) JoinChannel(channel config.ChannelInfo) error {
 
 func (b *Birc) Send(msg config.Message) (string, error) {
 	// ignore delete messages
-	if msg.Event == config.EventMsgDelete {
+	if msg.Event == config.EventMsgDelete ||
+	   msg.ID != "" {
 		return "", nil
 	}
 
@@ -179,13 +180,13 @@ func (b *Birc) Send(msg config.Message) (string, error) {
 	for i := range msgLines {
 		if len(b.Local) >= b.MessageQueue {
 			b.Log.Debugf("flooding, dropping message (queue at %d)", len(b.Local))
-			return "", nil
+			return "fake-id", nil
 		}
 
 		msg.Text = msgLines[i]
 		b.Local <- msg
 	}
-	return "", nil
+	return "fake-id", nil
 }
 
 func (b *Birc) doConnect() {

--- a/bridge/irc/irc.go
+++ b/bridge/irc/irc.go
@@ -218,6 +218,18 @@ func (b *Birc) createPaste(content string) string {
 	return result.Paste
 }
 
+func (b *Birc) RemoveEmpty(lines []string) []string {
+	var out []string
+
+	for _, l := range lines {
+		if l != "" {
+			out = append(out, l)
+		}
+	}
+
+	return out
+}
+
 func (b *Birc) Send(msg config.Message) (string, error) {
 	// ignore delete messages
 	if msg.Event == config.EventMsgDelete ||
@@ -280,6 +292,8 @@ func (b *Birc) Send(msg config.Message) (string, error) {
 	} else {
 		msgLines = helper.GetSubLines(msg.Text, 0, b.GetString("MessageClipped"))
 	}
+
+	msgLines = b.RemoveEmpty(msgLines)
 
 	originalText := msg.Text
 

--- a/bridge/irc/irc.go
+++ b/bridge/irc/irc.go
@@ -266,6 +266,8 @@ func (b *Birc) Send(msg config.Message) (string, error) {
 		msg.Text = stripmd.Strip(msg.Text)
 	}
 
+	originalText := msg.Text
+
 	if b.StripQuotes {
 		m1 := regexp.MustCompile(`(?ms)^> .*?^`)
 		msg.Text = m1.ReplaceAllString(msg.Text, "")
@@ -295,8 +297,6 @@ func (b *Birc) Send(msg config.Message) (string, error) {
 	}
 
 	msgLines = b.RemoveEmpty(msgLines)
-
-	originalText := msg.Text
 
 	for i := range msgLines {
 		if len(b.Local) >= b.MessageQueue {

--- a/bridge/irc/irc.go
+++ b/bridge/irc/irc.go
@@ -35,6 +35,7 @@ type Birc struct {
 	FirstConnection, authDone                 bool
 	MessageDelay, MessageQueue, MessageLength int
 	channels                                  map[string]bool
+	StripQuotes                               bool
 
 	PasteMinLines, PastePreviewLines   int
 	PasteDomain, PasteAPI, PasteAPIKey string
@@ -65,6 +66,7 @@ func New(cfg *bridge.Config) bridge.Bridger {
 	} else {
 		b.MessageLength = b.GetInt("MessageLength")
 	}
+	b.StripQuotes = b.GetBool("StripQuotes")
 	if b.GetInt("PasteMinLines") == 0 {
 		b.PasteMinLines = 4
 	} else {
@@ -273,8 +275,10 @@ func (b *Birc) Send(msg config.Message) (string, error) {
 			}
 		}
 
-		msg.Text = msgLines[i]
-		b.Local <- msg
+		if !b.StripQuotes || !strings.HasPrefix(msgLines[i], "> ") {
+			msg.Text = msgLines[i]
+			b.Local <- msg
+		}
 	}
 	return "fake-id", nil
 }

--- a/bridge/irc/irc.go
+++ b/bridge/irc/irc.go
@@ -40,7 +40,7 @@ type Birc struct {
 
 	PasteMinLines, PastePreviewLines   int
 	PasteDomain, PasteAPI, PasteAPIKey string
-	PasteCodeblocks                    bool
+	PasteCodeblocks, PasteLongMessages bool
 
 	*bridge.Config
 }
@@ -83,6 +83,7 @@ func New(cfg *bridge.Config) bridge.Bridger {
 	}
 	b.PasteAPIKey = b.GetString("PasteAPIKey")
 	b.PasteCodeblocks = b.GetBool("PasteCodeblocks")
+	b.PasteLongMessages = b.GetBool("PasteLongMessages")
 	b.FirstConnection = true
 	return b
 }
@@ -303,7 +304,8 @@ func (b *Birc) Send(msg config.Message) (string, error) {
 			return "fake-id", nil
 		}
 
-		if b.PasteDomain != "" && len(msgLines) >= b.PasteMinLines && i >= b.PastePreviewLines {
+		if b.PasteDomain != "" && b.PasteLongMessages &&
+		   len(msgLines) >= b.PasteMinLines && i >= b.PastePreviewLines {
 			var link string
 			link = b.createPaste(originalText)
 

--- a/bridge/irc/irc.go
+++ b/bridge/irc/irc.go
@@ -40,6 +40,7 @@ type Birc struct {
 
 	PasteMinLines, PastePreviewLines   int
 	PasteDomain, PasteAPI, PasteAPIKey string
+	PasteCodeblocks                    bool
 
 	*bridge.Config
 }
@@ -81,6 +82,7 @@ func New(cfg *bridge.Config) bridge.Bridger {
 		b.PasteAPI = b.GetString("PasteAPI")
 	}
 	b.PasteAPIKey = b.GetString("PasteAPIKey")
+	b.PasteCodeblocks = b.GetBool("PasteCodeblocks")
 	b.FirstConnection = true
 	return b
 }
@@ -254,6 +256,23 @@ func (b *Birc) Send(msg config.Message) (string, error) {
 	if b.StripQuotes {
 		m1 := regexp.MustCompile(`(?ms)^> .*?^`)
 		msg.Text = m1.ReplaceAllString(msg.Text, "")
+	}
+
+	if b.PasteDomain != "" && b.PasteCodeblocks {
+		m1 := regexp.MustCompile("(?ms)```(.*)```")
+
+		for true {
+			loc := m1.FindStringIndex(msg.Text)
+
+			if loc == nil {
+				break
+			}
+
+			substr := msg.Text[loc[0]:loc[1]]
+			link := b.createPaste(substr)
+
+			msg.Text = fmt.Sprintf("%s\n<codeblock clipped: %s>\n%s", msg.Text[0:loc[0]], link, msg.Text[loc[1]:])
+		}
 	}
 
 	if b.GetBool("MessageSplit") {

--- a/bridge/irc/irc.go
+++ b/bridge/irc/irc.go
@@ -305,7 +305,7 @@ func (b *Birc) Send(msg config.Message) (string, error) {
 		}
 
 		if b.PasteDomain != "" && b.PasteLongMessages &&
-		   len(msgLines) >= b.PasteMinLines && i >= b.PastePreviewLines {
+			len(msgLines) >= b.PasteMinLines && i >= b.PastePreviewLines {
 			var link string
 			link = b.createPaste(originalText)
 

--- a/bridge/irc/irc.go
+++ b/bridge/irc/irc.go
@@ -1,12 +1,15 @@
 package birc
 
 import (
+	"bytes"
 	"crypto/tls"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"hash/crc32"
 	"io/ioutil"
 	"net"
+	"net/http"
 	"sort"
 	"strconv"
 	"strings"
@@ -32,6 +35,9 @@ type Birc struct {
 	FirstConnection, authDone                 bool
 	MessageDelay, MessageQueue, MessageLength int
 	channels                                  map[string]bool
+
+	PasteMinLines, PastePreviewLines   int
+	PasteDomain, PasteAPI, PasteAPIKey string
 
 	*bridge.Config
 }
@@ -59,6 +65,19 @@ func New(cfg *bridge.Config) bridge.Bridger {
 	} else {
 		b.MessageLength = b.GetInt("MessageLength")
 	}
+	if b.GetInt("PasteMinLines") == 0 {
+		b.PasteMinLines = 4
+	} else {
+		b.PasteMinLines = b.GetInt("PasteMinLines")
+	}
+	b.PastePreviewLines = b.GetInt("PastePreviewLines")
+	b.PasteDomain = b.GetString("PasteDomain")
+	if b.GetString("PasteAPI") == "" {
+		b.PasteAPI = "https://" + b.PasteDomain + "/api"
+	} else {
+		b.PasteAPI = b.GetString("PasteAPI")
+	}
+	b.PasteAPIKey = b.GetString("PasteAPIKey")
 	b.FirstConnection = true
 	return b
 }
@@ -137,10 +156,67 @@ func (b *Birc) JoinChannel(channel config.ChannelInfo) error {
 	return nil
 }
 
+func (b *Birc) createPaste(content string) string {
+	type pasteRequestJson struct {
+		Paste    string `json:"paste"`
+		Language string `json:"language"`
+		Domain   string `json:"domain"`
+		ApiKey   string `json:"api_key,omitempty"`
+	}
+
+	type pasteResponseJson struct {
+		Err   string `json:"error"`
+		Paste string `json:"paste"`
+	}
+
+	request := pasteRequestJson{
+		Paste:    content,
+		Language: "markdown",
+		Domain:   fmt.Sprintf("%s/raw", b.PasteDomain),
+	}
+
+	if b.PasteAPIKey != "" {
+		request.ApiKey = b.PasteAPIKey
+	}
+
+	body, err := json.Marshal(request)
+
+	if err != nil {
+		b.Log.Errorf("Error encoding JSON for paste: %s", err.Error())
+		return ""
+	}
+
+	resp, err := http.Post(fmt.Sprintf("%s/v1/paste", b.PasteAPI), "application/json", bytes.NewBuffer(body))
+
+	if err != nil {
+		b.Log.Errorf("Error requesting paste: %s", err.Error())
+		return ""
+	}
+
+	if resp.StatusCode != 200 {
+		b.Log.Errorf("Got non-200 error code when creating paste: %d", resp.StatusCode)
+		return ""
+	}
+
+	result := pasteResponseJson{}
+	err = json.NewDecoder(resp.Body).Decode(&result)
+
+	if err != nil {
+		b.Log.Errorf("Failed to decode paste response JSON: %s", err.Error())
+		return ""
+	}
+
+	if result.Err != "" {
+		b.Log.Errorf("Got error in paste response: %s", result.Err)
+		return ""
+	}
+	return result.Paste
+}
+
 func (b *Birc) Send(msg config.Message) (string, error) {
 	// ignore delete messages
 	if msg.Event == config.EventMsgDelete ||
-	   msg.ID != "" {
+		msg.ID != "" {
 		return "", nil
 	}
 
@@ -177,10 +253,24 @@ func (b *Birc) Send(msg config.Message) (string, error) {
 	} else {
 		msgLines = helper.GetSubLines(msg.Text, 0, b.GetString("MessageClipped"))
 	}
+
+	originalText := msg.Text
+
 	for i := range msgLines {
 		if len(b.Local) >= b.MessageQueue {
 			b.Log.Debugf("flooding, dropping message (queue at %d)", len(b.Local))
 			return "fake-id", nil
+		}
+
+		if b.PasteDomain != "" && len(msgLines) >= b.PasteMinLines && i >= b.PastePreviewLines {
+			var link string
+			link = b.createPaste(originalText)
+
+			if link != "" {
+				msg.Text = "<message clipped: " + link + ">"
+				b.Local <- msg
+				return "fake-id", nil
+			}
 		}
 
 		msg.Text = msgLines[i]

--- a/bridge/irc/irc.go
+++ b/bridge/irc/irc.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -250,6 +251,11 @@ func (b *Birc) Send(msg config.Message) (string, error) {
 		msg.Text = stripmd.Strip(msg.Text)
 	}
 
+	if b.StripQuotes {
+		m1 := regexp.MustCompile(`(?ms)^> .*?^`)
+		msg.Text = m1.ReplaceAllString(msg.Text, "")
+	}
+
 	if b.GetBool("MessageSplit") {
 		msgLines = helper.GetSubLines(msg.Text, b.MessageLength, b.GetString("MessageClipped"))
 	} else {
@@ -275,10 +281,8 @@ func (b *Birc) Send(msg config.Message) (string, error) {
 			}
 		}
 
-		if !b.StripQuotes || !strings.HasPrefix(msgLines[i], "> ") {
-			msg.Text = msgLines[i]
-			b.Local <- msg
-		}
+		msg.Text = msgLines[i]
+		b.Local <- msg
 	}
 	return "fake-id", nil
 }


### PR DESCRIPTION
- Blocks edited messages
- Removes quotes (not as relevant anymore due to the new reply feature)
- Uploads long messages to a zifbin instance
- Uploads code blocks to a zifbin instance

Explanations of the different available options, since they aren't "just a few" anymore:

| Option | Description |
| --- | --- |
| `StripQuotes` | Entirely removes lines starting with `> ` from the sent message if enabled. (defaults to `false`) |
| `PasteMinLines` | If message has `<PasteMinLines>` or more, it sends it as a paste link instead. (defaults to `4`) |
| `PastePreviewLines` | Includes the first `<PastePreviewLines>` of the message before sending the paste link. (defaults to `0`) |
| `PasteDomain` | Selects the zifb.in instance where pastes are stored. If not set or empty, disables the whole paste feature. |
| `PasteAPI` | Overwrites the full API URL. (defaults to `https://<PasteDomain>/api`) |
| `PasteAPIKey` | zifb.in API key. |
| `PasteCodeblocks` | If enabled, removes code blocks from a message and replaces with a paste link. (defaults to `false`) |
| `PasteLongMessages` | If enabled, pastes too long messages (as configured above) to zifb.in and sends a link to that instead. (defaults to `false`) |

