### PR TITLE
Update the module name for our fork

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/42wim/matterbridge
+module github.com/lineageos-infra/matterbridge
 
 require (
 	github.com/42wim/go-gitter v0.0.0-20170828205020-017310c2d557


### PR DESCRIPTION
Otherwise, installing the module from the new URL fails.